### PR TITLE
Update http_server.cpp

### DIFF
--- a/src/world/http_server.cpp
+++ b/src/world/http_server.cpp
@@ -223,6 +223,7 @@ void HTTPServer::LockingUpdate()
 
         // Chars per zone
         {
+            apiDataCache.zonePlayerCounts.clear();
             auto rset = db::preparedStmt("SELECT chars.pos_zone, COUNT(*) AS `count` "
                                 "FROM chars "
                                 "INNER JOIN accounts_sessions "


### PR DESCRIPTION
API player counts per zone to clear old data.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x ] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [ x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

API for players per zone does not clear previous zone counts if they were >0 and now are =0

## Steps to test these changes

zoning and checking api data.
